### PR TITLE
Remove unused type variable from `is_attribute_field`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -1588,7 +1588,7 @@ end
 Return `true` if `field` is an attribute of the type `T`, and
 `false` otherwise.  Other fields are assumed to be elements.
 """
-is_attribute_field(::Type, field) where T = field === :public_id
+is_attribute_field(::Type, field) = field === :public_id
 is_attribute_field(::Type{Comment}, field) = field === :id
 is_attribute_field(::Type{NodalPlanes}, field) = field === :preferred_plane
 is_attribute_field(::Type{WaveformStreamID}, field) =


### PR DESCRIPTION
This produces a warning in precompilation on recent Julia versions,
so remove this to stop the warning.
