### PR TITLE
CI: Fix issue of trying to run x64 on macos-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,6 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
         arch:
           - x64
         include:
@@ -34,6 +33,9 @@ jobs:
           - os: ubuntu-latest
             version: 'nightly'
             arch: x64
+          - os: macos-latest
+            version: '1'
+            arch: aarch64
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
macOS runners on GitHub Actions are of course now aarch64 in terms
of architecture, but we had not updated CI to recognise this.
